### PR TITLE
Slidebook6 autogen docs

### DIFF
--- a/components/autogen/src/format-pages.txt
+++ b/components/autogen/src/format-pages.txt
@@ -27,6 +27,33 @@ Free software from 3I can export the files to OME-TIFF post-acquisition, see \n
 \n
 .. _Intelligent Imaging Innovations: http://www.intelligent-imaging.com/
 
+[3i SlideBook6]
+extensions = .sld
+owner = `Intelligent Imaging Innovations`_
+developer = `Intelligent Imaging Innovations`_
+bsd = no
+export = no
+versions = 4.1, 4.2, 5.0, 5.5, 6.0
+weHave = * Numerous SlideBook datasets
+weWant = * A SlideBook specification document \n
+* More SlideBook datasets (preferably acquired with the most recent SlideBook software)
+pixelsRating = Very good
+metadataRating = Fair
+opennessRating = Fair
+presenceRating = Very good
+utilityRating = Fair
+reader = SlideBook6Reader.java
+notes = As of Bioformats 5.1.2 the native binary file SlideBook6Reader.dll\n
+of the proper architecture (x32 or x64) must be in the java binary path for\n
+this  reader to work.  This file is available from\n
+`3i Support <mailto: support@intelligent-imaging.com>`_ and is currently\n
+only available for Windows systems.\n
+\n
+.. seealso:: \n
+  `Slidebook software overview <https://www.slidebook.com>`_ \n
+\n
+.. _Intelligent Imaging Innovations: http://www.intelligent-imaging.com/
+
 [Adobe Photoshop PSD]
 pagename = photoshop-psd
 extensions = .psd

--- a/docs/sphinx/formats/3i-slidebook6-metadata.txt
+++ b/docs/sphinx/formats/3i-slidebook6-metadata.txt
@@ -2,7 +2,7 @@
 SlideBook6Reader
 *******************************************************************************
 
-This page lists supported metadata fields for the Bio-Formats Slidebook 6 format reader.
+This page lists supported metadata fields for the Bio-Formats SlideBook 6 SLD (native) format reader.
 
 These fields are from the :model_doc:`OME data model <>`.
 Bio-Formats standardizes each format's original metadata to and from the OME
@@ -10,42 +10,27 @@ data model so that you can work with a particular piece of metadata (e.g.
 physical width of the image in microns) in a format-independent way.
 
 Of the 475 fields documented in the :doc:`metadata summary table </metadata-summary>`:
-  * The file format itself supports 52 of them (11%).
-  * Of those, Bio-Formats fully or partially converts 52 (100%).
+  * The file format itself supports 37 of them (7%).
+  * Of those, Bio-Formats fully or partially converts 37 (100%).
 
 Supported fields
 ===============================================================================
 
-These fields are fully supported by the Bio-Formats Slidebook 6 format reader:
-  * :schema:`Channel : AcquisitionMode <OME-2015-01/ome_xsd.html#Channel_AcquisitionMode>`
-  * :schema:`Channel : Color <OME-2015-01/ome_xsd.html#Channel_Color>`
-  * :schema:`Channel : EmissionWavelength <OME-2015-01/ome_xsd.html#EmissionWavelength>`
-  * :schema:`Channel : ExcitationWavelength <OME-2015-01/ome_xsd.html#ExcitationWavelength>`
+These fields are fully supported by the Bio-Formats SlideBook 6 SLD (native) format reader:
   * :schema:`Channel : ID <OME-2015-01/ome_xsd.html#Channel_ID>`
-  * :schema:`Channel : IlluminationType <OME-2015-01/ome_xsd.html#Channel_IlluminationType>`
-  * :schema:`Channel : NDFilter <OME-2015-01/ome_xsd.html#Channel_NDFilter>`
   * :schema:`Channel : Name <OME-2015-01/ome_xsd.html#Channel_Name>`
-  * :schema:`Channel : PockelCellSetting <OME-2015-01/ome_xsd.html#Channel_PockelCellSetting>`
   * :schema:`Channel : SamplesPerPixel <OME-2015-01/ome_xsd.html#Channel_SamplesPerPixel>`
-  * :schema:`DetectorSettings : AmplificationGain <OME-2015-01/ome_xsd.html#DetectorSettings_AmplificationGain>`
-  * :schema:`DetectorSettings : Binning <OME-2015-01/ome_xsd.html#DetectorSettings_Binning>`
-  * :schema:`DetectorSettings : ID <OME-2015-01/ome_xsd.html#DetectorSettings_ID>`
-  * :schema:`DetectorSettings : Integration <OME-2015-01/ome_xsd.html#DetectorSettings_Integration>`
-  * :schema:`DetectorSettings : Gain <OME-2015-01/ome_xsd.html#DetectorSettings_Gain>`
   * :schema:`Image : AcquisitionDate <OME-2015-01/ome_xsd.html#Image_AcquisitionDate>`
   * :schema:`Image : Description <OME-2015-01/ome_xsd.html#Image_Description>`
   * :schema:`Image : ID <OME-2015-01/ome_xsd.html#Image_ID>`
   * :schema:`Image : InstrumentRef <OME-2015-01/ome_xsd.html#InstrumentRef_ID>`
   * :schema:`Image : Name <OME-2015-01/ome_xsd.html#Image_Name>`
   * :schema:`Instrument : ID <OME-2015-01/ome_xsd.html#Instrument_ID>`
-  * :schema:`Detector : ID <OME-2015-01/ome_xsd.html#Detector_ID>`
-  * :schema:`Detector : Model <OME-2015-01/ome_xsd.html#Detector_Model>`
-  * :schema:`Detector : Type <OME-2015-01/ome_xsd.html#Detector_Type>`
+  * :schema:`Objective : Correction <OME-2015-01/ome_xsd.html#Objective_Correction>`
   * :schema:`Objective : ID <OME-2015-01/ome_xsd.html#Objective_ID>`
   * :schema:`Objective : Immersion <OME-2015-01/ome_xsd.html#Objective_Immersion>`
-  * :schema:`Objective : Immersion <OME-2015-01/ome_xsd.html#Objective_LensNA>`
+  * :schema:`Objective : Model <OME-2015-01/ome_xsd.html#ManufacturerSpec_Model>`
   * :schema:`Objective : NominalMagnification <OME-2015-01/ome_xsd.html#Objective_NominalMagnification>`
-  * :schema:`Objective : CalibratedMagnification <OME-2015-01/ome_xsd.html#Objective_CalibratedMagnification>`
   * :schema:`ObjectiveSettings : ID <OME-2015-01/ome_xsd.html#ObjectiveSettings_ID>`
   * :schema:`Pixels : BigEndian <OME-2015-01/ome_xsd.html#Pixels_BigEndian>`
   * :schema:`Pixels : DimensionOrder <OME-2015-01/ome_xsd.html#Pixels_DimensionOrder>`
@@ -70,6 +55,6 @@ These fields are fully supported by the Bio-Formats Slidebook 6 format reader:
   * :schema:`Plane : TheT <OME-2015-01/ome_xsd.html#Plane_TheT>`
   * :schema:`Plane : TheZ <OME-2015-01/ome_xsd.html#Plane_TheZ>`
 
-**Total supported: 52**
+**Total supported: 37**
 
-**Total unknown or missing: 423**
+**Total unknown or missing: 438**

--- a/docs/sphinx/formats/3i-slidebook6.txt
+++ b/docs/sphinx/formats/3i-slidebook6.txt
@@ -1,7 +1,7 @@
-.. index:: 3i SlideBook 6
+.. index:: 3i SlideBook6
 .. index:: .sld
 
-3i SlideBook
+3i SlideBook6
 ===============================================================================
 
 Extensions: .sld
@@ -12,13 +12,14 @@ Owner: `Intelligent Imaging Innovations`_
 
 **Support**
 
+
 BSD-licensed: |no|
 
 Export: |no|
 
 Officially Supported Versions: 4.1, 4.2, 5.0, 5.5, 6.0
 
-Supported Metadata Fields: :doc:`3i SlideBook <3i-slidebook6-metadata>`
+Supported Metadata Fields: :doc:`3i SlideBook6 <3i-slidebook6-metadata>`
 
 
 
@@ -32,6 +33,7 @@ We would like to have:
 * More SlideBook datasets (preferably acquired with the most recent SlideBook software)
 
 **Ratings**
+
 
 Pixels: |Very good|
 
@@ -51,9 +53,12 @@ Source Code: :bfreader:`SlideBook6Reader.java`
 
 Notes:
 
-As of Bioformats 5.1.2 the native binary file SlideBook6Reader.dll of the proper architecture (x32 or x64) 
-must be in the java binary path for this reader to work.  This file is available from `3i Support <mailto: support@intelligent-imaging.com>` 
-and is currently only available for Windows systems. _ 
+
+As of Bioformats 5.1.2 the native binary file SlideBook6Reader.dll
+of the proper architecture (x32 or x64) must be in the java binary path for
+this  reader to work.  This file is available from
+`3i Support <mailto: support@intelligent-imaging.com>`_ and is currently
+only available for Windows systems.
 
 .. seealso:: 
   `Slidebook software overview <https://www.slidebook.com>`_ 

--- a/docs/sphinx/supported-formats.txt
+++ b/docs/sphinx/supported-formats.txt
@@ -25,15 +25,6 @@ Supported Formats
      - .. image:: images/header-export.png
      - BSD
 
-   * - :doc:`formats/3i-slidebook6`
-     - .sld
-     - |Very good|
-     - |Fair|
-     - |Fair|
-     - |Very good|
-     - |Poor|
-     - |no|
-     - |no|
    * - :doc:`formats/3i-slidebook`
      - .sld
      - |Very good|
@@ -41,6 +32,15 @@ Supported Formats
      - |Fair|
      - |Very good|
      - |Poor|
+     - |no|
+     - |no|
+   * - :doc:`formats/3i-slidebook6`
+     - .sld
+     - |Very good|
+     - |Fair|
+     - |Fair|
+     - |Very good|
+     - |Fair|
      - |no|
      - |no|
    * - :doc:`formats/abd-tiff`
@@ -1313,7 +1313,7 @@ Supported Formats
      - |no|
      - |no|
 
-Bio-Formats currently supports **142** formats
+Bio-Formats currently supports **143** formats
 
 .. glossary::
     Ratings legend and definitions
@@ -1375,8 +1375,8 @@ Bio-Formats currently supports **142** formats
     :glob:
     :hidden:
 
-    formats/3i-slidebook6
     formats/3i-slidebook
+    formats/3i-slidebook6
     formats/abd-tiff
     formats/aim
     formats/alicona-3d


### PR DESCRIPTION
These commits should:
- port the documentation addition for the new SlideBook6Reader in https://github.com/openmicroscopy/bioformats/pull/1833 into the template `format-pages.txt` containing the metadata for the individual formats documentation
- re-generate the auto-generated pages from `components/autogen` using `ant gen-format-pages gen-meta-support gen-original-meta-support`

/cc @melissalinkert
